### PR TITLE
add linux-riscv64 toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,9 @@ RUN  export HOST=$(dpkg --print-architecture) \
         xz-utils:$HOST         \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV FREEBSD_AMD64_URL=https://download.freebsd.org/releases/amd64/amd64/ISO-IMAGES/12.4/FreeBSD-12.4-RELEASE-amd64-dvd1.iso.xz \
-     FREEBSD_I386_URL=https://download.freebsd.org/releases/i386/i386/ISO-IMAGES/12.4/FreeBSD-12.4-RELEASE-i386-dvd1.iso.xz \
-    FREEBSD_ARM64_URL=https://download.freebsd.org/releases/arm64/aarch64/ISO-IMAGES/12.4/FreeBSD-12.4-RELEASE-arm64-aarch64-dvd1.iso.xz
+ENV FREEBSD_AMD64_URL=https://download.freebsd.org/releases/amd64/amd64/ISO-IMAGES/14.4/FreeBSD-14.4-RELEASE-amd64-dvd1.iso.xz \
+     FREEBSD_I386_URL=https://download.freebsd.org/releases/i386/i386/ISO-IMAGES/14.4/FreeBSD-14.4-RELEASE-i386-dvd1.iso.xz \
+    FREEBSD_ARM64_URL=https://download.freebsd.org/releases/arm64/aarch64/ISO-IMAGES/14.4/FreeBSD-14.4-RELEASE-arm64-aarch64-dvd1.iso.xz
 
 # Unpack amd64 toolchain /usr/freebsd/x86_64-pc-freebsd12
 RUN mkdir -p /tmp/freebsd-amd64                                         \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim as environment
+FROM debian:trixie-slim as environment
 
 RUN  export HOST=$(dpkg --print-architecture) \
   && dpkg --add-architecture amd64    \
@@ -8,6 +8,7 @@ RUN  export HOST=$(dpkg --print-architecture) \
   && dpkg --add-architecture arm64    \
   && dpkg --add-architecture ppc64el  \
   && dpkg --add-architecture s390x    \
+  && dpkg --add-architecture riscv64  \
   && apt-get update                   \
   && apt-get install -yq              \
         clang:$HOST                   \
@@ -20,6 +21,7 @@ RUN  export HOST=$(dpkg --print-architecture) \
         crossbuild-essential-arm64    \
         crossbuild-essential-ppc64el  \
         crossbuild-essential-s390x    \
+        crossbuild-essential-riscv64  \
         libssl-dev                    \
         openssl                       \
         mingw-w64:$HOST               \

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following target platforms are currently supported:
 | arm64    |     x |      x |       x |         |
 | ppc64le  |     x |        |         |         |
 | s390x    |     x |        |         |         |
+| riscv64  |     x |        |         |         |
 
 ## Usage
 

--- a/rootfs/viceroycc-linux
+++ b/rootfs/viceroycc-linux
@@ -8,8 +8,9 @@ case "$VICEROYARCH" in
   arm64)    TOOLCHAIN_PREFIX="aarch64-linux-gnu-" ;;
   ppc64le)  TOOLCHAIN_PREFIX="powerpc64le-linux-gnu-" ;;
   s390x)    TOOLCHAIN_PREFIX="s390x-linux-gnu-" ;;
+  riscv64)  TOOLCHAIN_PREFIX="riscv64-linux-gnu-" ;;
   *)
-    echo "fatal: unsupported \$VICEROYARCH $VICEROYARCH for linux. Must be one of: amd64, 386, arm, arm64, ppc64le, s390x" >&2
+    echo "fatal: unsupported \$VICEROYARCH $VICEROYARCH for linux. Must be one of: amd64, 386, arm, arm64, ppc64le, s390x, riscv64" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
With the availability of Debian Trixie on riscv64, we can now easily add linux-riscv64 cross toolchain to viceroy. This is a dependency to get grafana/alloy on linux/riscv64.

Thank you for all your hard work!

cc @rfratto 